### PR TITLE
calling nextTick to wait for updates

### DIFF
--- a/tests/unit/Rating.spec.js
+++ b/tests/unit/Rating.spec.js
@@ -20,26 +20,30 @@ describe('Rating', () => {
         wrapper.findAll('.active').length
     ).toEqual(3)
   })
-  it('adds `active` class on an inactive star when the user clicks it', () => {
+  it('adds `active` class on an inactive star when the user clicks it', async () => {
     const fourthStar = wrapper.findAll('[data-test-id="star"]').at(3)
     fourthStar.trigger('click')
+    await wrapper.vm.$nextTick()
     expect(fourthStar.classes()).toContain('active')
   })
-  it('sets icon to `star` in an inactive star when the user clicks it', () => {
+  it('sets icon to `star` in an inactive star when the user clicks it', async () => {
     const fourthStar = wrapper.findAll('[data-test-id="star"]').at(3)
     fourthStar.trigger('click')
+    await wrapper.vm.$nextTick()
     expect(fourthStar.find('[data-test-id="icon"]').attributes().name).toEqual(
       'star'
     )
   })
-  it('removes `active` class on an active star when the user clicks it', () => {
+  it('removes `active` class on an active star when the user clicks it', async () => {
     const thirdStar = wrapper.findAll('[data-test-id="star"]').at(2)
     thirdStar.trigger('click')
+    await wrapper.vm.$nextTick()
     expect(thirdStar.classes()).not.toContain('active')
   })
-  it('sets icon to `regular/star` in an inactive star when the user clicks it', () => {
+  it('sets icon to `regular/star` in an inactive star when the user clicks it', async () => {
     const thirdStar = wrapper.findAll('[data-test-id="star"]').at(2)
     thirdStar.trigger('click')
+    await wrapper.vm.$nextTick()
     expect(thirdStar.find('[data-test-id="icon"]').attributes().name).toEqual(
       'regular/star'
     )
@@ -50,8 +54,9 @@ describe('Rating', () => {
   it('displays how many stars are active', () => {
     expect(wrapper.find('[data-test-id="counter"]').text()).toMatch('3 of 6')
   })
-  it('does not render a counter if prop.hasCounter is set to false', () => {
+  it('does not render a counter if prop.hasCounter is set to false', async () => {
     wrapper.setProps({ hasCounter: false })
+    await wrapper.vm.$nextTick()
     expect(wrapper.find('[data-test-id="counter"]').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
Tests must call nextTick to wait for updates before checking stuff that depends on reactive properties. This pull request makes the tests work.